### PR TITLE
Dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
-<div style="text-align: center;">
-
-# MCI | WING
-
-<div style="text-align: center;">
-  <img src="docs/assets/logo.png" alt="WING Logo" style="width: 200px; height: auto;">
+<div align="center">
+    <h1>MCI | WING</h1>
 </div>
 
----
+<p align="center">
+  <img src="docs/assets/logo.png" alt="WING Logo" style="width: 200px; height: auto;">
+</p>
 
-**Visit the site [here](https://mciwing.github.io/).**
+<div align="center">
+<hr>
 
+Visit the site <a href="https://mciwing.github.io/">here</a>
 </div>
 
 ---
@@ -59,6 +59,6 @@ poetry install
 poetry run mkdocs serve
 ```
 
-The site will be available at `localhost:8000`
+The site is served at `localhost:8000`
 
 </details>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,7 +87,7 @@ nav:
 plugins:
   - search
   - git-revision-date-localized:
-      enable_creation_date: true
+      enable_creation_date: false
       type: timeago
   - git-committers:
       repository: mciwing/mciwing.github.io

--- a/poetry.lock
+++ b/poetry.lock
@@ -410,13 +410,13 @@ dev = ["click", "codecov", "mkdocs-gen-files", "mkdocs-git-authors-plugin", "mkd
 
 [[package]]
 name = "mkdocs-material"
-version = "9.5.39"
+version = "9.5.42"
 description = "Documentation that simply works"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_material-9.5.39-py3-none-any.whl", hash = "sha256:0f2f68c8db89523cb4a59705cd01b4acd62b2f71218ccb67e1e004e560410d2b"},
-    {file = "mkdocs_material-9.5.39.tar.gz", hash = "sha256:25faa06142afa38549d2b781d475a86fb61de93189f532b88e69bf11e5e5c3be"},
+    {file = "mkdocs_material-9.5.42-py3-none-any.whl", hash = "sha256:452a7c5d21284b373f36b981a2cbebfff59263feebeede1bc28652e9c5bbe316"},
+    {file = "mkdocs_material-9.5.42.tar.gz", hash = "sha256:92779b5e9b5934540c574c11647131d217dc540dce72b05feeda088c8eb1b8f2"},
 ]
 
 [package.dependencies]
@@ -1031,4 +1031,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "7436c5a30256feb4b379d1d8b64e7d47a9f19d20649b45b4cfad7cfa56191dd6"
+content-hash = "38e35c822e3783ae9ce7b7e3a2864f1a5820538b71e27909bc8c847fe91bfe9a"

--- a/poetry.lock
+++ b/poetry.lock
@@ -372,13 +372,13 @@ pyyaml = ">=5.1"
 
 [[package]]
 name = "mkdocs-git-committers-plugin-2"
-version = "2.3.0"
+version = "2.4.1"
 description = "An MkDocs plugin to create a list of contributors on the page. The git-committers plugin will seed the template context with a list of GitHub or GitLab committers and other useful GIT info such as last modified date"
 optional = false
-python-versions = ">=3.8,<4"
+python-versions = "<4,>=3.8"
 files = [
-    {file = "mkdocs-git-committers-plugin-2-2.3.0.tar.gz", hash = "sha256:d6baca1ae04db8120640038eda8142f2d081c27b53f3b566c83c75717e4ed81a"},
-    {file = "mkdocs_git_committers_plugin_2-2.3.0-py3-none-any.whl", hash = "sha256:7b3434af3be525c12858eb3b44b4c6b695b7c7b7760482ea8de1c6e292e84f0f"},
+    {file = "mkdocs_git_committers_plugin_2-2.4.1-py3-none-any.whl", hash = "sha256:ec9c1d81445606c471337d1c4a1782c643b7377077b545279dc18b86b7362c6d"},
+    {file = "mkdocs_git_committers_plugin_2-2.4.1.tar.gz", hash = "sha256:ea1f80a79cedc42289e0b8e973276df04fb94f56e0ae3efc5385fb28547cf5cb"},
 ]
 
 [package.dependencies]
@@ -388,13 +388,13 @@ requests = "*"
 
 [[package]]
 name = "mkdocs-git-revision-date-localized-plugin"
-version = "1.2.9"
+version = "1.3.0"
 description = "Mkdocs plugin that enables displaying the localized date of the last git modification of a markdown file."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mkdocs_git_revision_date_localized_plugin-1.2.9-py3-none-any.whl", hash = "sha256:dea5c8067c23df30275702a1708885500fadf0abfb595b60e698bffc79c7a423"},
-    {file = "mkdocs_git_revision_date_localized_plugin-1.2.9.tar.gz", hash = "sha256:df9a50873fba3a42ce9123885f8c53d589e90ef6c2443fe3280ef1e8d33c8f65"},
+    {file = "mkdocs_git_revision_date_localized_plugin-1.3.0-py3-none-any.whl", hash = "sha256:c99377ee119372d57a9e47cff4e68f04cce634a74831c06bc89b33e456e840a1"},
+    {file = "mkdocs_git_revision_date_localized_plugin-1.3.0.tar.gz", hash = "sha256:439e2f14582204050a664c258861c325064d97cdc848c541e48bb034a6c4d0cb"},
 ]
 
 [package.dependencies]
@@ -1031,4 +1031,4 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11,<3.13"
-content-hash = "38e35c822e3783ae9ce7b7e3a2864f1a5820538b71e27909bc8c847fe91bfe9a"
+content-hash = "3071810097636e642bcb5b9993754a0574a9e47d00da0e1f4e0cc56c1319e421"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ mkdocs-material = "^9.5.42"
 
 
 [tool.poetry.group.plugins.dependencies]
-mkdocs-git-revision-date-localized-plugin = "^1.2.8"
-mkdocs-git-committers-plugin-2 = "^2.3.0"
+mkdocs-git-revision-date-localized-plugin = "^1.3.0"
+mkdocs-git-committers-plugin-2 = "^2.4.1"
 mkdocs-table-reader-plugin = "^3.1.0"
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ package-mode = false
 
 [tool.poetry.dependencies]
 python = ">=3.11,<3.13"
-mkdocs-material = "^9.5.37"
+mkdocs-material = "^9.5.42"
 
 
 [tool.poetry.group.plugins.dependencies]


### PR DESCRIPTION
Closes #37

- Updated all dependencies
- Centered some content in the `README.md`
- `mkdocs.yml`: Set `enable_creation_date` to `False`, since it displays simply the last build date of the site on every page (most likely due to our set-up with GitHub actions).
