### PR TITLE
Explicitly define headings in `mkdocs.yml`

### DIFF
--- a/docs/data-science/data/preparation.md
+++ b/docs/data-science/data/preparation.md
@@ -1,4 +1,4 @@
-# Data preparation
+# Data Preparation
 
 ## Preface
 

--- a/docs/data-science/data/preprocessing.md
+++ b/docs/data-science/data/preprocessing.md
@@ -1,4 +1,4 @@
-# Data preprocessing
+# Data Preprocessing
 
 ![Continue your quest!](../../assets/data-science/data/continue-quest.png)
 <figcaption style="text-align: center;">

--- a/docs/data-science/practice/index.md
+++ b/docs/data-science/practice/index.md
@@ -1,4 +1,4 @@
-# Data Science in practice
+# Data Science in Practice
 
 ## Introduction
 

--- a/docs/python-extensive/data/tabular.md
+++ b/docs/python-extensive/data/tabular.md
@@ -1,4 +1,4 @@
-# Tabular data
+# Tabular Data
 
 With a couple of practical examples, we will discover tips on how to work with
 tabular data, where to find it, and the various sources and formats you

--- a/docs/python/comparisons_and_logic.md
+++ b/docs/python/comparisons_and_logic.md
@@ -1,4 +1,4 @@
-# Comparisons & Logical operators
+# Comparisons & Logical Operators
 
 ## Comparisons
 

--- a/docs/python/control-structures/if.md
+++ b/docs/python/control-structures/if.md
@@ -1,4 +1,4 @@
-# More control structures
+# More Control Structures
 
 ## Introduction
 

--- a/docs/python/index.md
+++ b/docs/python/index.md
@@ -1,4 +1,4 @@
-# Motivation
+# Home
 
 ![header](../assets/header/pcc.png)
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,7 +33,7 @@ nav:
   - Home: index.md
 
   - Python Crash Course:
-    - python/index.md
+    - Home: python/index.md
     - Installation: python/installation.md
     - IDE: python/ide.md
     - Variables: python/variables.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,34 +136,34 @@ nav:
         - statistics/regression/LinearRegression.md
 
   - Data Science:
-      - data-science/index.md
+      - Home: data-science/index.md
 
       - Data Basics:
-        - data-science/data-basics/terms.md
-        - data-science/data-basics/data.md
-        - "Data Basics": data-science/data-basics/basics.md
+        - Definition of Key Terms: data-science/data-basics/terms.md
+        - Data vs. Big Data: data-science/data-basics/data.md
+        - Data Basics: data-science/data-basics/basics.md
 
       - Data Preparation & Preprocessing:
-        - data-science/data/preparation.md
-        - data-science/data/preprocessing.md
+        - Data Preparation: data-science/data/preparation.md
+        - Data Preprocessing: data-science/data/preprocessing.md
 
       - Supervised vs. Unsupervised Learning:
-        - data-science/algorithms/index.md
+        - Introduction: data-science/algorithms/index.md
 
         - Supervised:
-          - data-science/algorithms/supervised/regression.md
-          - data-science/algorithms/supervised/classification.md
-          - Tree based:
+          - Regression: data-science/algorithms/supervised/regression.md
+          - Classification: data-science/algorithms/supervised/classification.md
+          - Tree Based:
             - Decision Tree: data-science/algorithms/supervised/tree-based/cart.md
             - Random Forest: data-science/algorithms/supervised/tree-based/forest.md
 
         - Unsupervised:
-          - data-science/algorithms/unsupervised/clustering.md
-          - data-science/algorithms/unsupervised/dim-reduction.md
+          - Clustering: data-science/algorithms/unsupervised/clustering.md
+          - Dimensionality Reduction: data-science/algorithms/unsupervised/dim-reduction.md
 
       - Data Science in Practice:
           - Introduction: data-science/practice/index.md
-          - 1. Data preparation: data-science/practice/data-preparation.md
+          - 1. Data Preparation: data-science/practice/data-preparation.md
           - 2. Modelling: data-science/practice/modelling.md
           - 3. End-to-End: data-science/practice/end-to-end.md
           - Bonus: data-science/practice/bonus.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,75 +34,75 @@ nav:
 
   - Python Crash Course:
     - python/index.md
-    - python/installation.md
-    - python/ide.md
-    - python/variables.md
+    - Installation: python/installation.md
+    - IDE: python/ide.md
+    - Variables: python/variables.md
 
     - Types:
-      - python/types/strings.md
-      - python/types/numbers.md
-      - python/types/bool_and_none.md
+      - Strings: python/types/strings.md
+      - Integers & Floats: python/types/numbers.md
+      - Boolean & None: python/types/bool_and_none.md
 
-    - python/comparisons_and_logic.md
+    - Comparisons & Logical Operators: python/comparisons_and_logic.md
 
     - Containers:
-      - python/containers/list.md
-      - python/containers/dict.md
-      - python/containers/tuple.md
+      - Lists: python/containers/list.md
+      - Dictionaries: python/containers/dict.md
+      - Tuples: python/containers/tuple.md
 
     - Control Structures:
-      - python/control-structures/for.md
-      - python/control-structures/if.md
+      - Loops: python/control-structures/for.md
+      - More Control Structures: python/control-structures/if.md
 
-    - python/functions.md
-    - python/packages.md
-    - python/pandas.md
+    - Functions: python/functions.md
+    - Package Management: python/packages.md
+    - Pandas: python/pandas.md
 
   - Python Extensive Course:
     - Home: python-extensive/index.md
 
     - Basics & Data Types:
       - Setup:
-        - python-extensive/installation.md
-        - "IDE": python-extensive/ide.md
+        - Installation: python-extensive/installation.md
+        - IDE: python-extensive/ide.md
 
-      - python-extensive/variables.md
+      - Variables: python-extensive/variables.md
 
       - Types:
-        - python-extensive/types/strings.md
-        - python-extensive/types/numbers.md
-        - python-extensive/types/bool_and_none.md
+        - Strings: python-extensive/types/strings.md
+        - Integers & Floats: python-extensive/types/numbers.md
+        - Boolean & None: python-extensive/types/bool_and_none.md
 
     - Logic & Containers:
-      - python-extensive/comparisons_and_logic.md
+      - Comparisons & Logical Operators: python-extensive/comparisons_and_logic.md
 
       - Containers:
-        - python-extensive/containers/list.md
-        - python-extensive/containers/dict.md
-        - python-extensive/containers/tuple.md
+        - Lists: python-extensive/containers/list.md
+        - Dictionaries: python-extensive/containers/dict.md
+        - Tuples: python-extensive/containers/tuple.md
 
     - Control Structures & Functions:
       - Control Structures:
-        - python-extensive/control-structures/for.md
-        - python-extensive/control-structures/if.md
+        - Loops: python-extensive/control-structures/for.md
+        - More Control Structures: python-extensive/control-structures/if.md
 
-      - python-extensive/functions.md  # TODO: methods vs. functions; variable scope
+      - Functions: python-extensive/functions.md  # TODO: methods vs. functions; variable scope
 
     - Dev Tools & Data Handling:
-      - python-extensive/packages.md
-      - python-extensive/pandas.md
-      - python-extensive/plotting.md
+      - Package Management: python-extensive/packages.md
+      - Pandas: python-extensive/pandas.md
+      - Plotting: python-extensive/plotting.md
 
     - Data Acquisition & Export:
-      - "Data Basics": python-extensive/DataBasics.md
-      - "Data Acquisition":
-        - python-extensive/data/tabular.md
-        - python-extensive/data/api.md
+      - Data Basics: python-extensive/DataBasics.md
+      - Data Acquisition:
+        - Tabular Data: python-extensive/data/tabular.md
+        - API: python-extensive/data/api.md
 
     - Graphical User Interface:
-      - python-extensive/oop.md
-      - python-extensive/tkinter.md
-      - python-extensive/streamlit.md
+      - Object-Oriented Programming: python-extensive/oop.md
+      - Graphical User Interfaces with Tkinter: python-extensive/tkinter.md
+      - Building Web Applications with Streamlit: python-extensive/streamlit.md
 
   - Statistics:
     - statistics/index.md


### PR DESCRIPTION
Explicitly define and unify all headings in the `mkdocs.yml` for following courses:

- Python Crash Course
- Python Extensive Course
- Data Science