### PR TITLE
Workflow to check if site can be built

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,5 +36,5 @@ jobs:
       - name: Install the project
         run: uv sync --locked
 
-      - name: Build the site and deploy
+      - name: Build the site
         run: uv run mkdocs build --strict


### PR DESCRIPTION
Whenever a pull request on main is opened the workflow triggers and checks if the site can be built. Ensures that we only merge a working site.