### PR TITLE
Exlcude blog from displaying the creation date of posts

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -224,6 +224,8 @@ plugins:
         # has an issue with git --follow
         # see https://timvink.github.io/mkdocs-git-revision-date-localized-plugin/options/#enable_git_follow
         - python-extensive/data/api.md
+        # posts have their own date displayed in metadata
+        - blog/*
       enabled: !ENV [ENABLE_GIT_REVISION_DATE, true]
 
   - git-authors:


### PR DESCRIPTION
Blog posts have their own creation data displayed on the left hand side, hence the whole directory is excluded from the `git-revision-date-localized` plugin.