### PR TITLE
chore (fix): add CNAME

### DIFF
--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+code-campus.at


### PR DESCRIPTION
## Issue

The publish action deletes the CNAME file, since `mkdocs gh-deploy --force` overwrites all files.

## Solution

Add the CNAME to the main branch. `mkdocs gh-deploy` will use that - see [docs](https://www.mkdocs.org/user-guide/deploying-your-docs/#custom-domains)